### PR TITLE
Fix unilumos_infer_image.py: feed input image into foreground (x_deg) channel

### DIFF
--- a/UniLumos/UniLumos/unilumos_infer_image.py
+++ b/UniLumos/UniLumos/unilumos_infer_image.py
@@ -119,9 +119,16 @@ def main(args):
         for idx, data_i in enumerate(tqdm(dataloader, desc="Inference Progress", disable=not verbose)):
 
             # Extract data from dataloader
-            video_ref = data_i['video'].to(device, dtype)  # Reference image as a single-frame video
+            video_ref = data_i['video'].to(device, dtype)  # Input subject image as a single-frame video (foreground)
+
+            # Feed the input image into the foreground/degradation channel (x_deg) so the model
+            # actually relights the subject. Previously this was zeroed, which dropped the input
+            # image from the conditioning and collapsed inference to text-only generation (issue #6).
+            video_degradation = video_ref.clone()
+
+            # Leave the background empty (pure color) -- the captions + foreground setting (ab mode).
+            # The model then generates a background consistent with the target lighting caption.
             video_background = torch.zeros_like(video_ref)
-            video_degradation = torch.zeros_like(video_ref)
 
             # get prompts
             if 'text' in data_i:


### PR DESCRIPTION
## Summary

Fixes the broken output from `unilumos_infer_image.py` reported in #6.

`unilumos_infer_image.py` zeroed **both** conditioning tensors:

```python
video_background  = torch.zeros_like(video_ref)
video_degradation = torch.zeros_like(video_ref)
```

The core model conditions on `torch.cat([z, x_deg, x_bg], dim=1)` plus the caption (`src/models/wanx/core_model.py`), where `x_deg` is the **foreground/subject** branch (the `ab` script calls it "captions and foreground videos", and the paper describes it as the strong conditional signal carrying the subject). Because `x_deg` was zeroed, the encoded input image never reached the model — only the random noise `z`, an empty background, and the text caption did. Inference therefore collapsed to **pure text-to-image generation**, which is why the input subject is not preserved in the results posted in #6.

## Fix

Route the input image into the foreground channel `x_deg`, matching the captions + foreground (`ab`) setting. The background is left empty so it is generated from the lighting caption.

```python
video_degradation = video_ref.clone()        # foreground subject -> x_deg
video_background  = torch.zeros_like(video_ref)  # empty bg (pure color), generated from caption
```

This mirrors how `unilumos_infer_ab.py` conditions the model (foreground kept, background zeroed), adapted to single-frame image input.

## Notes / verification

- Verified the change is consistent with the paper's task formulation and the working `ab`/`abc` pipelines, and that the file compiles (`python -m py_compile`).